### PR TITLE
Changed default values to the ones we're actually using on the site to reduce setup steps

### DIFF
--- a/lib/spree/calculator/shipping/korean_surface_mail.rb
+++ b/lib/spree/calculator/shipping/korean_surface_mail.rb
@@ -1,9 +1,9 @@
 class Spree::Calculator::KoreanSurfaceMail <  Spree::Calculator
   #The rates are calculated using two different price_brackets the upper limit
   #is set here and can be overridden by the admin
-  preference :limit_currency, :string, :default => 'KRW'
-  preference :lower_price_bracket_minimum, :integer, :default => 0
-  preference :lower_price_bracket_limit, :integer, :default => 200000
+  preference :limit_currency, :string, :default => 'USD'
+  preference :lower_price_bracket_minimum, :integer, :default => 200
+  preference :lower_price_bracket_limit, :integer, :default => 200
   #Depending on the price bracket the maximum weight (kg) of a package is decided
   preference :lower_price_bracket_max_weight, :decimal, :default => 20.00
   preference :upper_price_bracket_max_weight, :decimal, :default => 30.00


### PR DESCRIPTION
Change defaults to:
- Limit currency: USD
- Lower price bracket minimum: 200 (USD)
- Lower price bracket limit: 200 (USD)

These are the settings we're actually using on the site, so this reduces the number of admin config steps that need to be done on a new server.
